### PR TITLE
Add accessor and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Bash utilities used by Expression Atlas
+
+This is a module factored out of legacy code to provide common bash utilities to Atlas scripts. 
+
+## Usage
+
+Any of the bash functions from generic_routines.sh can be accessed via the `atlas-bash-utils` accessor script, like:
+
+```
+> atlas-bash-util capitalize_first_letter foo
+Foo
+```

--- a/atlas-bash-util
+++ b/atlas-bash-util
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $scriptDir/generic_routines.sh
+
+$@


### PR DESCRIPTION
Rather than many Atlas scripts sourcing generic_functions.sh from our private atlas-prod repo, I propose that we make these functions available via a single accessor which we can provide via Conda and Docker. 

I have a few things I can add to this from other repos, will be nice to regularise and expand it. 