### PR TITLE
Add LSF script and accessory funcs

### DIFF
--- a/atlas-lsf
+++ b/atlas-lsf
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $scriptDir/generic_routines.sh
+source $scriptDir/lsf.sh
+
+usageOpts="[ -c <command string> ] \
+           [ -w <working directory, default current working directory> ] \
+           [ -m <memory in Mb, defaults to cluster defalt> ] \
+           [ -p <number of cores, defaults to cluster defalt> ] \
+           [ -j <job name, defaults to cluster default ] \
+           [ -g <job group name, defaults to cluster default ] \
+           [ -l <log prefix, no logs written by default ] \
+           [ -m <monitor submitted job? Defaults to yes> ] \
+           [ -f <poll frequency in seconds if job is monitored. Defaults to 10.> ] \
+           [ -q <lsf queue, defaults to cluster default ]"
+
+usageOpts=$(echo -e "$usageOpts" | tr -s " ")
+usage() { echo "Usage: $0 $usageOpts"; }
+
+# Parse arguments
+
+commandString=
+workingDir=
+memory=
+cores=
+jobName=
+queue=
+jobGroupName=
+logPrefix=
+monitorJob=yes
+pollFreqSecs=10
+
+while getopts ":c:w:m:p:j:g:l:m:f:q:" o; do
+    case "${o}" in
+        c)
+            commandString=${OPTARG}
+            ;;
+        w)
+            workingDir=${OPTARG}
+            ;;
+        m)
+            memory=${OPTARG}
+            ;;
+        p)
+            cores=${OPTARG}
+            ;;
+        j)
+            jobName=${OPTARG}
+            ;;
+        q)
+            queue=${OPTARG}
+            ;;
+        g)
+            jobGroupName=${OPTARG}
+            ;;
+        l)
+            logPrefix=${OPTARG}
+            ;;
+        m)
+            monitorJob=${OPTARG}
+            ;;
+        f)
+            pollFreqSecs=${OPTARG}
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
+# Submit the jobs
+
+lsfJobId=$(lsf_submit "$commandString" "$jobQueue" "$jobName" "$memory" "$cores" "$jobGroupName" "$workingDir" "$logPrefix")
+submitStatus=$?
+
+if [ "$submitStatus" -ne "0" ] && [ -n "$lsfJobId" ]; then
+    die "Job submission failed, status is $submitStatus"
+else
+    echo "Job submission succeeded, received job ID $lsfJobId"
+    
+    if [ "$monitorJob" = 'yes' ]; then
+        logFile=
+        if [ -n "$logPrefix" ]; then
+            logFile=${logPrefix}.out
+        fi 
+
+        finalStatus=$(lsf_monitor_job "$lsfJobId" "$pollFreqSecs" "$logFile")
+        if [ "$finalStatus" != 'DONE' ]; then
+            die "Command \"$commandString\" failed, status $finalStatus"
+        fi
+    fi
+fi

--- a/atlas-lsf
+++ b/atlas-lsf
@@ -12,6 +12,7 @@ usageOpts="[ -c <command string> ] \
            [ -g <job group name, defaults to cluster default ] \
            [ -l <log prefix, no logs written by default ] \
            [ -m <monitor submitted job? Defaults to yes> ] \
+           [ -s <monitor style: 'status' for job status updates on polling, 'std_out_err' to report ongoing content of logs (where used). Defaults to std_out_err> ] \
            [ -f <poll frequency in seconds if job is monitored. Defaults to 10.> ] \
            [ -q <lsf queue, defaults to cluster default ]"
 
@@ -30,8 +31,9 @@ jobGroupName=
 logPrefix=
 monitorJob=yes
 pollFreqSecs=10
+monitorStyle=std_out_err
 
-while getopts ":c:w:m:p:j:g:l:n:f:q:" o; do
+while getopts ":c:w:m:p:j:g:l:n:f:q:s:" o; do
     case "${o}" in
         c)
             commandString=${OPTARG}
@@ -63,6 +65,9 @@ while getopts ":c:w:m:p:j:g:l:n:f:q:" o; do
         f)
             pollFreqSecs=${OPTARG}
             ;;
+        s)
+            monitorStyle=${OPTARG}
+            ;;
         *)
             usage
             exit 0
@@ -86,9 +91,9 @@ else
             logFile=${logPrefix}.out
         fi 
 
-        finalStatus=$(lsf_monitor_job "$lsfJobId" "$pollFreqSecs" "$logFile")
-        if [ "$finalStatus" != 'DONE' ]; then
-            die "Command \"$commandString\" failed, status $finalStatus"
+        lsf_monitor_job "$lsfJobId" "$pollFreqSecs" "$logFile" "$monitorStyle"
+        if [ $? -ne 0 ]; then
+            die "Command \"$commandString\" failed"
         fi
     fi
 fi

--- a/atlas-lsf
+++ b/atlas-lsf
@@ -31,7 +31,7 @@ logPrefix=
 monitorJob=yes
 pollFreqSecs=10
 
-while getopts ":c:w:m:p:j:g:l:m:f:q:" o; do
+while getopts ":c:w:m:p:j:g:l:n:f:q:" o; do
     case "${o}" in
         c)
             commandString=${OPTARG}
@@ -57,7 +57,7 @@ while getopts ":c:w:m:p:j:g:l:m:f:q:" o; do
         l)
             logPrefix=${OPTARG}
             ;;
-        m)
+        n)
             monitorJob=${OPTARG}
             ;;
         f)

--- a/lsf.sh
+++ b/lsf.sh
@@ -29,8 +29,6 @@ lsf_submit(){
         mkdir -p $(dirname $logPrefix)
     fi
 
-    # Check that we're not running this job already
-   
     local bsub_cmd=$(echo -e "bsub $jobQueue $jobName $lsfMem $nThreads $jobGroupName $workingDir $logPrefix \"$commandString\"" | tr -s " ")
 
     local bsubOutput=

--- a/lsf.sh
+++ b/lsf.sh
@@ -1,0 +1,107 @@
+# Submit a job to the cluster
+
+lsf_submit(){
+    local commandString="$1"
+    local jobQueue="$2"
+    local jobName="$3"
+    local lsfMem="$4"
+    local nThreads="$5"
+    local jobGroupName="$6"       
+    local workingDir="$7"
+    local logPrefix="$8"
+
+    # Need at least the command string
+
+    if [ -z "$commandString" ]; then
+        die "Need at least a command string for LSF submission"
+    fi
+
+    # Check parameter settings
+
+    if [ -n "$jobQueue" ]; then jobQueue=" -q ${jobQueue}"; fi
+    if [ -n "$jobName" ]; then jobName=" -J ${jobName}"; fi
+    if [ -n "$lsfMem" ]; then lsfMem=" -R \"rusage[mem=$lsfMem]\" -M $lsfMem"; fi
+    if [ -n "$nThreads" ]; then nThreads=" -R \"span[ptile=$nThreads]\" -n $nThreads"; fi
+    if [ -n "$jobGroupName" ]; then jobGroupName=" -g $jobGroupName"; fi
+    if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
+    if [ -n "$logPrefix" ]; then 
+        logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}\""; 
+        mkdir -p $(dirname $logPrefix)
+    fi
+
+    # Check that we're not running this job already
+   
+    local bsub_cmd=$(echo -e "bsub $jobQueue $jobName $lsfMem $nThreads $jobGroupName $workingDir $logPrefix \"$commandString\"" | tr -s " ")
+
+    local bsubOutput=
+    bsubOutput=$(eval $bsub_cmd)
+
+    # Assuming submission was successful, extract the job ID
+
+    if [ $? -ne 0 ]; then
+        die "Job submission failed"
+    else
+        echo $bsubOutput | head -n1 | cut -d'<' -f2 | cut -d'>' -f1
+    fi
+}
+
+# Check lsf status for a job
+
+lsf_job_status() {
+    local jobId=$1
+    local jobStdout=$2
+
+    check_variables 'jobId'
+
+    local errCode=
+    local jobStatus=$(bjobs -a -o "stat" --job_id $jobId | tail -n +2)
+    local logPath=
+    
+    if [ -z "$jobStdout" ]; then 
+        jobStdout=$(bjobs -l $jobId)
+    elif [ -f "$jobStdout" ]; then
+        logMsg=", check logs at $jobStdout."    
+        jobStdout="$(cat $jobStdout)"
+    fi
+
+    if [ "$jobStatus" = "DONE" ] || [ "$jobStatus" = "" ]; then
+        echo -e "$jobStdout" | grep -q 'Done successfully.'
+        if [ $? -eq 0 ]; then         
+            warn "Successful run for $jobId!" 1>&2
+        else
+            warn "Failure for job ${jobId}${logMsg}"
+            errCode=1
+        fi
+    elif [ "$jobStatus" = "EXIT" ]; then
+        warn "Job $jobId had exit status ${jobStatus}${logMsg}"
+        errCode=1
+    fi
+
+    echo -n "$jobStatus"
+    return $errCode
+}
+
+# Monitor running of a particular job
+
+lsf_monitor_job() {
+    local jobId=$1
+    local pollSecs=${2:-10}
+    local jobStdout=$3
+    
+    local lsfJobStatus=$(lsf_job_status "$jobId" "$jobStdout")
+    local lastStatus=$lsfJobStatus
+    echo -en "Starting status is ${lsfJobStatus}" 1>&2
+
+    while [ "$lsfJobStatus" = 'PEND' ] || [ "$lsfJobStatus" = 'RUN' ]; do
+        echo -n '.' 1>&2
+        sleep $pollSecs
+        lsfJobStatus=$(lsf_job_status "$jobId" "$jobStdout" 2>/dev/null)
+        if [ "$lsfJobStatus" != "$lastStatus" ]; then
+            echo -en "\nStatus is now ${lsfJobStatus}" 1>&2
+            lastStatus=$lsfJobStatus
+        fi
+    done
+    echo -e "\n" 1>&2
+    echo -n "$lsfJobStatus"
+} 
+


### PR DESCRIPTION
This PR adds some simplified LSF submission logic for cases when we're not using e.g. Snakemake to manage submissions, for example when we're submitting the top level of those workflows. Principally this is for interactive waiting for jobs to run and checking of errors, to be used in Jenkins etc where we currently replicate LSF submission logic hard-coded in the jobs.

Parameters here will also allow operation across our different compute environments. 

Usage:

```
atlas-lsf -h
Usage: ./atlas-lsf [ -c <command string> ] [ -w <working directory, default current working directory> ] [ -m <memory in Mb, defaults to cluster defalt> ] [ -p <number of cores, defaults to cluster defalt> ] [ -j <job name, defaults to cluster default ] [ -g <job group name, defaults to cluster default ] [ -l <log prefix, no logs written by default ] [ -m <monitor submitted job? Defaults to yes> ] [ -f <poll frequency in seconds if job is monitored. Defaults to 10.> ] [ -q <lsf queue, defaults to cluster default ]
```

Examples:

Submit a job but don't keep track of it:

```
> atlas-lsf -c "sleep 10" -f 2 -n no
Job submission succeeded, received job ID 5308898
```

Submit and monitor a job, see that it completes without error:

```
 > atlas-lsf -c "sleep 10" -f 2 -s status
Job submission succeeded, received job ID 5308537
Starting status is PEND...
Status is now RUN.....
Status is now DONE

> echo $?
0
```

Submit and monitor a job and see that it fails:

```
> atlas-lsf -c "sleep 10; exit 5" -f 2 -s status
Job submission succeeded, received job ID 5308510
Starting status is PEND...
Status is now RUN.....
Status is now EXIT

Command "sleep 10; exit 5" failed, status EXIT
> echo $?
1
```

View STDOUT and STDERR of the job as it runs (this is the default style):

```
> ./atlas-lsf -c "echo ONE;sleep 5;echo TWO;echo ERROR 1>&2;sleep 5;echo THREE;echo BOO! 1>&2;" -l $(pwd)/foo -f 2 -s std_out_err
Job submission succeeded, received job ID 5316059
Monitor style: std_out_err
==> /path/to/foo.err <==

==> /path/to/foo.out <==

==> /path/to/foo.err <==
ERROR

==> /path/to/foo.out <==
ONE
TWO

==> /path/to/foo.err <==
BOO!

==> /path/to/foo.out <==
THREE

------------------------------------------------------------
Sender: LSF System <lsf@foo-cluster-47-01>
Subject: Job 5316059: <echo ONE;sleep 5;echo TWO;echo ERROR 1>&2;sleep 5;echo THREE;echo BOO! 1>&2> in cluster <cluster> Done

Job <echo ONE;sleep 5;echo TWO;echo ERROR 1>&2;sleep 5;echo THREE;echo BOO! 1>&2> was submitted from host <foo-cluster-08-04> by user <user> in cluster <cluster> at Thu Dec  2 17:36:28 2021
Job was executed on host(s) <foo-cluster-47-01>, in queue <standard>, as user <user> in cluster <cluster> at Thu Dec  2 17:36:29 2021
</homes/user> was used as the home directory.
</path/to> was used as the working directory.
Started at Thu Dec  2 17:36:29 2021
Terminated at Thu Dec  2 17:36:40 2021
Results reported at Thu Dec  2 17:36:40 2021

Your job looked like:

------------------------------------------------------------
# LSBATCH: User input
echo ONE;sleep 5;echo TWO;echo ERROR 1>&2;sleep 5;echo THREE;echo BOO! 1>&2;
------------------------------------------------------------

Successfully completed.

Resource usage summary:

    CPU time :                                   0.04 sec.
    Max Memory :                                 6 MB
    Average Memory :                             6.00 MB
    Total Requested Memory :                     -
    Delta Memory :                               -
    Max Swap :                                   -
    Max Processes :                              3
    Max Threads :                                4
    Run time :                                   10 sec.
    Turnaround time :                            12 sec.

The output (if any) is above this job summary.



PS:

Read file </path/to/foo.err> for stderr output of this job.
```

