### PR TITLE
Allow use of btop to push jobs up queue

### DIFF
--- a/atlas-lsf
+++ b/atlas-lsf
@@ -34,8 +34,9 @@ logCleanup=no
 monitorJob=yes
 pollFreqSecs=10
 monitorStyle=std_out_err
+prioritise=no
 
-while getopts ":c:w:m:p:j:g:l:e:n:f:q:s:" o; do
+while getopts ":c:w:m:p:j:g:l:e:n:f:q:s:r:" o; do
     case "${o}" in
         c)
             commandString=${OPTARG}
@@ -73,6 +74,9 @@ while getopts ":c:w:m:p:j:g:l:e:n:f:q:s:" o; do
         s)
             monitorStyle=${OPTARG}
             ;;
+        r)
+            prioritise=${OPTARG}
+            ;;
         *)
             usage
             exit 0
@@ -82,7 +86,7 @@ done
 
 # Submit the jobs
 
-lsfJobId=$(lsf_submit "$commandString" "$queue" "$jobName" "$memory" "$cores" "$jobGroupName" "$workingDir" "$logPrefix")
+lsfJobId=$(lsf_submit "$commandString" "$queue" "$jobName" "$memory" "$cores" "$jobGroupName" "$workingDir" "$logPrefix" "$prioritise")
 submitStatus=$?
 
 if [ "$submitStatus" -ne "0" ] && [ -n "$lsfJobId" ]; then

--- a/lsf.sh
+++ b/lsf.sh
@@ -9,6 +9,7 @@ lsf_submit(){
     local jobGroupName="$6"       
     local workingDir="$7"
     local logPrefix="$8"
+    local prioritise="$9"
 
     # Need at least the command string
 
@@ -39,7 +40,12 @@ lsf_submit(){
     if [ $? -ne 0 ]; then
         die "Job submission failed"
     else
-        echo $bsubOutput | head -n1 | cut -d'<' -f2 | cut -d'>' -f1
+        local jobId=$(echo $bsubOutput | head -n1 | cut -d'<' -f2 | cut -d'>' -f1)
+        if [ "$prioritise" = 'yes' ]; then
+            warn "Prioritising $jobId"
+            btop $jobId
+        fi
+        echo $jobId
     fi
 }
 


### PR DESCRIPTION
This PR allows use of btop to push jobs to top of queue. This is important for e.g. control jobs that coordinate lots of others, and should have priority over other child processes. 