### PR TITLE
Fix log diretory creation

### DIFF
--- a/lsf.sh
+++ b/lsf.sh
@@ -26,8 +26,8 @@ lsf_submit(){
     if [ -n "$jobGroupName" ]; then jobGroupName=" -g $jobGroupName"; fi
     if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
     if [ -n "$logPrefix" ]; then 
-        logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}.err\""; 
         mkdir -p $(dirname $logPrefix)
+        logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}.err\""; 
     fi
 
     local bsub_cmd=$(echo -e "bsub $jobQueue $jobName $lsfMem $nThreads $jobGroupName $workingDir $logPrefix \"$commandString\"" | tr -s " ")

--- a/lsf.sh
+++ b/lsf.sh
@@ -27,7 +27,7 @@ lsf_submit(){
     if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
     if [ -n "$logPrefix" ]; then 
         mkdir -p $(dirname $logPrefix)
-        logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}.err\""; 
+        logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}.err\""
     fi
 
     local bsub_cmd=$(echo -e "bsub $jobQueue $jobName $lsfMem $nThreads $jobGroupName $workingDir $logPrefix \"$commandString\"" | tr -s " ")


### PR DESCRIPTION
Fixes a bug where the logPrefix variable is re-written before it's used to make sure the output dir exists.