### PR TITLE
Sleep briefly before cleaning up logs

### DIFF
--- a/lsf.sh
+++ b/lsf.sh
@@ -145,6 +145,11 @@ lsf_monitor_job() {
         wait $pid > /dev/null 2>&1
         if [ "$logCleanup" = 'yes' ]; then
             echo "Cleaning up logs $jobStdout, $jobStderr"
+            
+            # Sleep for a bit before we delete, otherwise it seems like the
+            # tail we killed above doesn't quite finish reporting 
+           
+            sleep 10 
             rm -rf $jobStdout $jobStderr
         fi
     fi


### PR DESCRIPTION
We sometimes miss the end of processes, I think because logs are removed before the 'tail' process finishes reporting. So just give it a few seconds before actually removing the logs. 