### PR TITLE
Feature/lsf conda env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Usage:
 atlas-lsf -h
 Usage: ./atlas-lsf [ -c <command string> ] \
     [ -w <working directory, default current working directory> ] \
-    [ -m <memory in Mb, defaults to cluster defalt> ] \
-    [ -p <number of cores, defaults to cluster defalt> ] \
+    [ -m <memory in Mb, defaults to cluster default> ] \
+    [ -p <number of cores, defaults to cluster default> ] \
     [ -j <job name, defaults to cluster default> ] \
     [ -g <job group name, defaults to cluster default> ] \
     [ -l <log prefix, no logs written by default> ] \
@@ -40,6 +40,7 @@ Usage: ./atlas-lsf [ -c <command string> ] \
     [ -m <monitor submitted job? Defaults to yes> ] \
     [ -f <poll frequency in seconds if job is monitored. Defaults to 10.> ] \
     [ -q <lsf queue, defaults to cluster default ]
+    [ -v <name of the conda environment in which to run the job> ]
 ```
 
 Examples:
@@ -144,4 +145,13 @@ PS:
 Read file </path/to/foo.err> for stderr output of this job.
 ```
 
+Submit a job that should run in a conda environment:
+
+```
+> atlas-lsf -v myenv -c "echo $CONDA_PREFIX > myenv.txt" -f 2 -n no
+Job submission succeeded, received job ID 2711148
+
+>cat myenv.txt
+/hps/software/users/GTL/user/miniconda3/envs/myenv
+```
 

--- a/atlas-lsf
+++ b/atlas-lsf
@@ -6,8 +6,8 @@ source $scriptDir/lsf.sh
 
 usageOpts="[ -c <command string> ] \
            [ -w <working directory, default current working directory> ] \
-           [ -m <memory in Mb, defaults to cluster defalt> ] \
-           [ -p <number of cores, defaults to cluster defalt> ] \
+           [ -m <memory in Mb, defaults to cluster default> ] \
+           [ -p <number of cores, defaults to cluster default> ] \
            [ -j <job name, defaults to cluster default> ] \
            [ -g <job group name, defaults to cluster default> ] \
            [ -l <log prefix, no logs written by default> ] \
@@ -15,7 +15,8 @@ usageOpts="[ -c <command string> ] \
            [ -m <monitor submitted job? Defaults to yes> ] \
            [ -s <monitor style: 'status' for job status updates on polling, 'std_out_err' to report ongoing content of logs (where used). Defaults to std_out_err> ] \
            [ -f <poll frequency in seconds if job is monitored. Defaults to 10.> ] \
-           [ -q <lsf queue, defaults to cluster default ]"
+           [ -q <lsf queue, defaults to cluster default> ] \
+           [ -v <name of the conda environment in which to run the job> ]"
 
 usageOpts=$(echo -e "$usageOpts" | tr -s " ")
 usage() { echo "Usage: $0 $usageOpts"; }
@@ -36,7 +37,7 @@ pollFreqSecs=10
 monitorStyle=std_out_err
 prioritise=no
 
-while getopts ":c:w:m:p:j:g:l:e:n:f:q:s:r:" o; do
+while getopts ":c:w:m:p:j:g:l:e:n:f:q:s:r:v:" o; do
     case "${o}" in
         c)
             commandString=${OPTARG}
@@ -77,6 +78,9 @@ while getopts ":c:w:m:p:j:g:l:e:n:f:q:s:r:" o; do
         r)
             prioritise=${OPTARG}
             ;;
+        v)
+            condaEnv=${OPTARG}
+            ;;
         *)
             usage
             exit 0
@@ -86,7 +90,7 @@ done
 
 # Submit the jobs
 
-lsfJobId=$(lsf_submit "$commandString" "$queue" "$jobName" "$memory" "$cores" "$jobGroupName" "$workingDir" "$logPrefix" "$prioritise")
+lsfJobId=$(lsf_submit "$commandString" "$queue" "$jobName" "$memory" "$cores" "$jobGroupName" "$workingDir" "$logPrefix" "$prioritise" "$condaEnv")
 submitStatus=$?
 
 if [ "$submitStatus" -ne "0" ] && [ -n "$lsfJobId" ]; then

--- a/lsf.sh
+++ b/lsf.sh
@@ -27,8 +27,8 @@ lsf_submit(){
     if [ -n "$jobGroupName" ]; then jobGroupName=" -g $jobGroupName"; fi
     if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
     if [ -n "$condaEnv" ]; then
-        condaBase=$(dirname "$( which conda )" )
-        condaCmd=". ${condaBase}/activate ${condaBase}/../envs/${condaEnv}"
+        condaBase=$(conda info --json | awk '/conda_prefix/ { gsub(/"|,/, "", $2); print $2 }')
+        condaCmd=". ${condaBase}/bin/activate ${condaBase}/envs/${condaEnv}"
         commandString="${condaCmd} && ${commandString}"
     fi
     if [ -n "$logPrefix" ]; then 

--- a/lsf.sh
+++ b/lsf.sh
@@ -10,6 +10,7 @@ lsf_submit(){
     local workingDir="$7"
     local logPrefix="$8"
     local prioritise="$9"
+    local condaEnv="${10}"
 
     # Need at least the command string
 
@@ -25,6 +26,11 @@ lsf_submit(){
     if [ -n "$nThreads" ]; then nThreads=" -R \"span[ptile=$nThreads]\" -n $nThreads"; fi
     if [ -n "$jobGroupName" ]; then jobGroupName=" -g $jobGroupName"; fi
     if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
+    if [ -n "$condaEnv" ]; then
+        condaBase=$(dirname "$( which conda )" )
+        condaCmd=". ${condaBase}/activate ${condaBase}/../envs/${condaEnv}"
+        commandString="${condaCmd} && ${commandString}"
+    fi
     if [ -n "$logPrefix" ]; then 
         mkdir -p $(dirname $logPrefix)
         logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}.err\""


### PR DESCRIPTION
Add an option to specify the conda environment in which to run the atlas LSF job
Reference: https://github.com/ebi-gene-expression-group/atlas-bash-util/issues/9