### PR TITLE
Some fixes to allow code refactoring in reprocessing pipeline

### DIFF
--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -180,13 +180,12 @@ move_ena_experiments_to_isl_studies() {
 # Applies fixes encoded in $fixesFile to $exp.$fileTypeToBeFixed.txt
 applyFixes() {
 	exp=$1
-	fixesFile=$2
+	fixesFilePath=$2
 	fileTypeToBeFixed=$3
-	fixesFilePath=$4
 
 	echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
 	# Apply factor type fixes in ${fileTypeToBeFixed} file
-	for l in $(cat $fixesFilePath/$fixesFile | sed 's|[[:space:]]*$||g') ; do
+	for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g') ; do
 		if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
 			warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
 			return 1
@@ -198,7 +197,7 @@ applyFixes() {
 		correct=$(echo $l | awk -F"\t" '{print $1}')
 		toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
 
-		if [ "$fixesFile" == "automatic_fixes_properties.txt" ]; then
+		if [ "$(basename $fixesFilePath)" == "automatic_fixes_properties.txt" ]; then
 			# in sdrf or condensed-sdrv fix factor/characteristic types only
 			if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
 				# In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
@@ -208,7 +207,7 @@ applyFixes() {
 				perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
 				perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
 			fi
-		elif [ "$fixesFile" == "automatic_fixes_values.txt" ]; then
+		elif [ "$(basename $fixesFilePath)" == "automatic_fixes_values.txt" ]; then
 			if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
 				# In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
 				perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
@@ -219,23 +218,23 @@ applyFixes() {
 
 applyAllFixesForExperiment() {
 	exp=$1
-	fixesfilepath=$2
+	fixesFileDir=$2
 	echo "Applying fixes for $exp ..."
 	# Apply factor type fixes in idf file
-	applyFixes $exp automatic_fixes_properties.txt idf.txt $fixesfilepath
+	applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt idf.txt
 	if [ $? -ne 0 ]; then
 		warn "ERROR: Applying factor type fixes in idf file for $exp failed"
 		return 1
 	fi
 
 	# Apply factor/sample characteristic type fixes to the condensed-sdrf file
-	applyFixes $exp automatic_fixes_properties.txt condensed-sdrf.tsv $fixesfilepath
+	applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt condensed-sdrf.tsv
 	if [ $? -ne 0 ]; then
 		echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
 		return 1
 	fi
 	# Apply sample characteristic/factor value fixes to the condensed-sdrf file
-	applyFixes $exp automatic_fixes_values.txt condensed-sdrf.tsv $fixesfilepath
+	applyFixes $exp $fixesFileDir/automatic_fixes_values.txt condensed-sdrf.tsv
     if [ $? -ne 0 ]; then
 		echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
 		return 1

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -70,13 +70,6 @@ send_report() {
     rm -rf ${log}.out ${log}.err ${log}.report
 }
 
-# Returns prod or test, depending on the Atlas environment in which the script calling it is running
-# It is assuming that all atlasinstall_<env>s are under ${ATLAS_PROD}/sw (it will fail otherwise)
-atlas_env() {
-    scriptDir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-    atlasInstallSubDir=$(echo $scriptDir | awk -F"/" '{print $8}')
-    echo $atlasInstallSubDir | awk -F"_" '{print $2}'
-}
 
 # This procedure returns 0 if process $arg is running; otherwise it returns 1
 lsf_process_running() {
@@ -188,7 +181,7 @@ applyFixes() {
     exp=$1
     fixesFilePath=$2
     fileTypeToBeFixed=$3
-    atlasEnv=$(atlas_env)
+    atlasEnv='prod'
 
     echo 
 

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -122,7 +122,7 @@ peach_api_release_date() {
         releaseDate="$(date --date="2 days ago" +%Y-%m-%d)"
     fi
 
-	echo $releaseDate
+    echo $releaseDate
 }
 
 enad_experiment() {
@@ -179,67 +179,67 @@ move_ena_experiments_to_isl_studies() {
 
 # Applies fixes encoded in $fixesFile to $exp.$fileTypeToBeFixed.txt
 applyFixes() {
-        exp=$1
-        fixesFilePath=$2
-        fileTypeToBeFixed=$3
+    exp=$1
+    fixesFilePath=$2
+    fileTypeToBeFixed=$3
 
-        echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
-        # Apply factor type fixes in ${fileTypeToBeFixed} file
-        for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g') ; do
-                if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
-                        warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
-                        return 1
-                fi
-                echo $l | grep -P '\t' >/dev/null
-                if [ $? -ne 0 ]; then
-                        echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
-                fi
-                correct=$(echo $l | awk -F"\t" '{print $1}')
-                toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
+    echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
+    # Apply factor type fixes in ${fileTypeToBeFixed} file
+    for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g') ; do
+        if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
+            warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
+            return 1
+        fi
+        echo $l | grep -P '\t' >/dev/null
+        if [ $? -ne 0 ]; then
+            echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
+        fi
+        correct=$(echo $l | awk -F"\t" '{print $1}')
+        toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
 
-                if [ "$(basename $fixesFilePath)" == "automatic_fixes_properties.txt" ]; then
-                        # in sdrf or condensed-sdrv fix factor/characteristic types only
-                        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-                                # In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
-                                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-                        else
-                                # idf
-                                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-                                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-                        fi
-                elif [ "$(basename $fixesFilePath)" == "automatic_fixes_values.txt" ]; then
-                        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-                                # In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
-                                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-                        fi
-                fi
-        done
+        if [ "$(basename $fixesFilePath)" == "automatic_fixes_properties.txt" ]; then
+            # in sdrf or condensed-sdrv fix factor/characteristic types only
+            if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+                # In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
+                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+            else
+                # idf
+                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+            fi
+        elif [ "$(basename $fixesFilePath)" == "automatic_fixes_values.txt" ]; then
+            if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+                # In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
+                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+            fi
+        fi
+    done
 }
 
 applyAllFixesForExperiment() {
-        exp=$1
-        fixesFileDir=$2
-        echo "Applying fixes for $exp ..."
-        # Apply factor type fixes in idf file
-        applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt idf.txt
-        if [ $? -ne 0 ]; then
-                warn "ERROR: Applying factor type fixes in idf file for $exp failed"
-                return 1
-        fi
+    exp=$1
+    fixesFileDir=$2
+    echo "Applying fixes for $exp ..."
+    # Apply factor type fixes in idf file
+    applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt idf.txt
+    if [ $? -ne 0 ]; then
+        warn "ERROR: Applying factor type fixes in idf file for $exp failed"
+        return 1
+    fi
 
-        # Apply factor/sample characteristic type fixes to the condensed-sdrf file
-        applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt condensed-sdrf.tsv
-        if [ $? -ne 0 ]; then
-                echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
-                return 1
-        fi
-        # Apply sample characteristic/factor value fixes to the condensed-sdrf file
-        applyFixes $exp $fixesFileDir/automatic_fixes_values.txt condensed-sdrf.tsv
-        if [ $? -ne 0 ]; then
-                echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
-                return 1
-        fi
-        echo "applyAllFixesForExperiment...done"
+    # Apply factor/sample characteristic type fixes to the condensed-sdrf file
+    applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt condensed-sdrf.tsv
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
+        return 1
+    fi
+    # Apply sample characteristic/factor value fixes to the condensed-sdrf file
+    applyFixes $exp $fixesFileDir/automatic_fixes_values.txt condensed-sdrf.tsv
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
+        return 1
+    fi
+    echo "applyAllFixesForExperiment...done"
 }
 
 # Restriction to run prod scripts as the prod user only

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -122,7 +122,7 @@ peach_api_release_date() {
         releaseDate="$(date --date="2 days ago" +%Y-%m-%d)"
     fi
 
-    echo $releaseDate
+	echo $releaseDate
 }
 
 enad_experiment() {
@@ -179,68 +179,68 @@ move_ena_experiments_to_isl_studies() {
 
 # Applies fixes encoded in $fixesFile to $exp.$fileTypeToBeFixed.txt
 applyFixes() {
-    exp=$1
-    fixesFile=$2
-    fileTypeToBeFixed=$3
-    fixesFilePath=$4
-    
-    echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
-    # Apply factor type fixes in ${fileTypeToBeFixed} file
-    for l in $(cat $fixesFilePath/$fixesFile | sed 's|[[:space:]]*$||g') ; do
-	    if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
-	        warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
-	        return 1
-	    fi
-        echo $l | grep -P '\t' >/dev/null
-        if [ $? -ne 0 ]; then
-            echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
-        fi
-	    correct=$(echo $l | awk -F"\t" '{print $1}')
-	    toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
+	exp=$1
+	fixesFile=$2
+	fileTypeToBeFixed=$3
+	fixesFilePath=$4
 
-	    if [ "$fixesFile" == "automatic_fixes_properties.txt" ]; then
-	        # in sdrf or condensed-sdrv fix factor/characteristic types only
-	        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-		        # In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
-		        perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-	        else
-		        # idf
-		        perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-		        perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-	        fi
-	    elif [ "$fixesFile" == "automatic_fixes_values.txt" ]; then
-	        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-		        # In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
-		        perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-	        fi
-	    fi
-    done
+	echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
+	# Apply factor type fixes in ${fileTypeToBeFixed} file
+	for l in $(cat $fixesFilePath/$fixesFile | sed 's|[[:space:]]*$||g') ; do
+		if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
+			warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
+			return 1
+		fi
+		echo $l | grep -P '\t' >/dev/null
+		if [ $? -ne 0 ]; then
+			echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
+		fi
+		correct=$(echo $l | awk -F"\t" '{print $1}')
+		toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
+
+		if [ "$fixesFile" == "automatic_fixes_properties.txt" ]; then
+			# in sdrf or condensed-sdrv fix factor/characteristic types only
+			if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+				# In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
+				perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+			else
+				# idf
+				perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+				perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+			fi
+		elif [ "$fixesFile" == "automatic_fixes_values.txt" ]; then
+			if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+				# In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
+				perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+			fi
+		fi
+	done
 }
 
 applyAllFixesForExperiment() {
-    exp=$1
-    fixesfilepath=$2
-    echo "Applying fixes for $exp ..."
-    # Apply factor type fixes in idf file
-    applyFixes $exp automatic_fixes_properties.txt idf.txt $fixesfilepath
-    if [ $? -ne 0 ]; then
-	    warn "ERROR: Applying factor type fixes in idf file for $exp failed"
-	    return 1
-    fi
+	exp=$1
+	fixesfilepath=$2
+	echo "Applying fixes for $exp ..."
+	# Apply factor type fixes in idf file
+	applyFixes $exp automatic_fixes_properties.txt idf.txt $fixesfilepath
+	if [ $? -ne 0 ]; then
+		warn "ERROR: Applying factor type fixes in idf file for $exp failed"
+		return 1
+	fi
 
-    # Apply factor/sample characteristic type fixes to the condensed-sdrf file
-    applyFixes $exp automatic_fixes_properties.txt condensed-sdrf.tsv $fixesfilepath
+	# Apply factor/sample characteristic type fixes to the condensed-sdrf file
+	applyFixes $exp automatic_fixes_properties.txt condensed-sdrf.tsv $fixesfilepath
+	if [ $? -ne 0 ]; then
+		echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
+		return 1
+	fi
+	# Apply sample characteristic/factor value fixes to the condensed-sdrf file
+	applyFixes $exp automatic_fixes_values.txt condensed-sdrf.tsv $fixesfilepath
     if [ $? -ne 0 ]; then
-	    echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
-	    return 1
-    fi
-    # Apply sample characteristic/factor value fixes to the condensed-sdrf file
-    applyFixes $exp automatic_fixes_values.txt condensed-sdrf.tsv $fixesfilepath
-    if [ $? -ne 0 ]; then
-	    echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
-	    return 1
-    fi
-    echo "applyAllFixesForExperiment...done"
+		echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
+		return 1
+	fi
+	echo "applyAllFixesForExperiment...done"
 }
 
 # Restriction to run prod scripts as the prod user only

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -185,7 +185,7 @@ applyFixes() {
 
     echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
     # Apply factor type fixes in ${fileTypeToBeFixed} file
-    for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g') ; do
+    for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g'); do
         if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
             warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
             return 1

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -176,44 +176,44 @@ move_ena_experiments_to_isl_studies() {
     fi
 }
 
+
 # Applies fixes encoded in $fixesFile to $exp.$fileTypeToBeFixed.txt
 applyFixes() {
     exp=$1
-    fixesFilePath=$2
+    fixesFile=$2
     fileTypeToBeFixed=$3
     atlasEnv='prod'
 
-    echo 
-
+    echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
     # Apply factor type fixes in ${fileTypeToBeFixed} file
-    for l in $($cat fixesFilePath | sed 's|[[:space:]]*$||g'); do
-        if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
-            warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
-            return 1
-        fi
+    for l in $(cat $ATLAS_PROD/sw/atlasinstall_${atlasEnv}/atlasprod/experiment_metadata/$fixesFile | sed 's|[[:space:]]*$||g') ; do
+	    if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
+	        warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
+	        return 1
+	    fi
         echo $l | grep -P '\t' >/dev/null
         if [ $? -ne 0 ]; then
             echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
         fi
-        correct=$(echo $l | awk -F"\t" '{print $1}')
-        toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
+	    correct=$(echo $l | awk -F"\t" '{print $1}')
+	    toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
 
-        if [ "$(basename $fixesFilePath)" == "automatic_fixes_properties.txt" ]; then
-            # in sdrf or condensed-sdrv fix factor/characteristic types only
-            if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-                # In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
-                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-            else
-                # idf
-                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-            fi
-        elif [ "$(basename $fixesFilePath)" == "automatic_fixes_values.txt" ]; then
-            if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-                # In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
-                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-            fi
-        fi
+	    if [ "$fixesFile" == "automatic_fixes_properties.txt" ]; then
+	        # in sdrf or condensed-sdrv fix factor/characteristic types only
+	        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+		        # In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
+		        perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+	        else
+		        # idf
+		        perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+		        perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+	        fi
+	    elif [ "$fixesFile" == "automatic_fixes_values.txt" ]; then
+	        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+		        # In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
+		        perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+	        fi
+	    fi
     done
 }
 
@@ -223,21 +223,23 @@ applyAllFixesForExperiment() {
     # Apply factor type fixes in idf file
     applyFixes $exp automatic_fixes_properties.txt idf.txt
     if [ $? -ne 0 ]; then
-        warn "ERROR: Applying factor type fixes in idf file for $exp failed"
+	    warn "ERROR: Applying factor type fixes in idf file for $exp failed"
+	    return 1
     fi
 
     # Apply factor/sample characteristic type fixes to the condensed-sdrf file
     applyFixes $exp automatic_fixes_properties.txt condensed-sdrf.tsv
     if [ $? -ne 0 ]; then
-        echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
-        return 1
+	    echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
+	    return 1
     fi
     # Apply sample characteristic/factor value fixes to the condensed-sdrf file
     applyFixes $exp automatic_fixes_values.txt condensed-sdrf.tsv
     if [ $? -ne 0 ]; then
-        echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
-        return 1
+	    echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
+	    return 1
     fi
+    echo "applyAllFixesForExperiment...done"
 }
 
 # Restriction to run prod scripts as the prod user only

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -179,67 +179,67 @@ move_ena_experiments_to_isl_studies() {
 
 # Applies fixes encoded in $fixesFile to $exp.$fileTypeToBeFixed.txt
 applyFixes() {
-	exp=$1
-	fixesFilePath=$2
-	fileTypeToBeFixed=$3
+        exp=$1
+        fixesFilePath=$2
+        fileTypeToBeFixed=$3
 
-	echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
-	# Apply factor type fixes in ${fileTypeToBeFixed} file
-	for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g') ; do
-		if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
-			warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
-			return 1
-		fi
-		echo $l | grep -P '\t' >/dev/null
-		if [ $? -ne 0 ]; then
-			echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
-		fi
-		correct=$(echo $l | awk -F"\t" '{print $1}')
-		toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
+        echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
+        # Apply factor type fixes in ${fileTypeToBeFixed} file
+        for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g') ; do
+                if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
+                        warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
+                        return 1
+                fi
+                echo $l | grep -P '\t' >/dev/null
+                if [ $? -ne 0 ]; then
+                        echo "WARNING: line: '$l' in automatic_fixes_properties.txt is missing a tab character - not applying the fix "
+                fi
+                correct=$(echo $l | awk -F"\t" '{print $1}')
+                toBeReplaced=$(echo $l | awk -F"\t" '{print $2}' | sed 's/[^-A-Za-z0-9_ ]/\\\&/g')
 
-		if [ "$(basename $fixesFilePath)" == "automatic_fixes_properties.txt" ]; then
-			# in sdrf or condensed-sdrv fix factor/characteristic types only
-			if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-				# In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
-				perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-			else
-				# idf
-				perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
-				perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-			fi
-		elif [ "$(basename $fixesFilePath)" == "automatic_fixes_values.txt" ]; then
-			if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
-				# In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
-				perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
-			fi
-		fi
-	done
+                if [ "$(basename $fixesFilePath)" == "automatic_fixes_properties.txt" ]; then
+                        # in sdrf or condensed-sdrv fix factor/characteristic types only
+                        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+                                # In condensed-sdrf, the factor/characteristic type is the penultimate column - so tabs on both sides
+                                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+                        else
+                                # idf
+                                perl -pi -e "s|\t${toBeReplaced}\t|\t${correct}\t|g" $exp/$exp.${fileTypeToBeFixed}
+                                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+                        fi
+                elif [ "$(basename $fixesFilePath)" == "automatic_fixes_values.txt" ]; then
+                        if [ "$fileTypeToBeFixed" == "condensed-sdrf.tsv" ]; then
+                                # In condensed-sdrf, the factor/characteristic value is the last column - so tab on the left and line ending on the right
+                                perl -pi -e "s|\t${toBeReplaced}$|\t${correct}|g" $exp/$exp.${fileTypeToBeFixed}
+                        fi
+                fi
+        done
 }
 
 applyAllFixesForExperiment() {
-	exp=$1
-	fixesFileDir=$2
-	echo "Applying fixes for $exp ..."
-	# Apply factor type fixes in idf file
-	applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt idf.txt
-	if [ $? -ne 0 ]; then
-		warn "ERROR: Applying factor type fixes in idf file for $exp failed"
-		return 1
-	fi
+        exp=$1
+        fixesFileDir=$2
+        echo "Applying fixes for $exp ..."
+        # Apply factor type fixes in idf file
+        applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt idf.txt
+        if [ $? -ne 0 ]; then
+                warn "ERROR: Applying factor type fixes in idf file for $exp failed"
+                return 1
+        fi
 
-	# Apply factor/sample characteristic type fixes to the condensed-sdrf file
-	applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt condensed-sdrf.tsv
-	if [ $? -ne 0 ]; then
-		echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
-		return 1
-	fi
-	# Apply sample characteristic/factor value fixes to the condensed-sdrf file
-	applyFixes $exp $fixesFileDir/automatic_fixes_values.txt condensed-sdrf.tsv
-    	if [ $? -ne 0 ]; then
-		echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
-		return 1
-	fi
-	echo "applyAllFixesForExperiment...done"
+        # Apply factor/sample characteristic type fixes to the condensed-sdrf file
+        applyFixes $exp $fixesFileDir/automatic_fixes_properties.txt condensed-sdrf.tsv
+        if [ $? -ne 0 ]; then
+                echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
+                return 1
+        fi
+        # Apply sample characteristic/factor value fixes to the condensed-sdrf file
+        applyFixes $exp $fixesFileDir/automatic_fixes_values.txt condensed-sdrf.tsv
+        if [ $? -ne 0 ]; then
+                echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
+                return 1
+        fi
+        echo "applyAllFixesForExperiment...done"
 }
 
 # Restriction to run prod scripts as the prod user only

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -235,7 +235,7 @@ applyAllFixesForExperiment() {
 	fi
 	# Apply sample characteristic/factor value fixes to the condensed-sdrf file
 	applyFixes $exp $fixesFileDir/automatic_fixes_values.txt condensed-sdrf.tsv
-    if [ $? -ne 0 ]; then
+    	if [ $? -ne 0 ]; then
 		echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
 		return 1
 	fi

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -182,11 +182,11 @@ applyFixes() {
     exp=$1
     fixesFile=$2
     fileTypeToBeFixed=$3
-    atlasEnv='prod'
-
+    fixesFilePath=$4
+    
     echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
     # Apply factor type fixes in ${fileTypeToBeFixed} file
-    for l in $(cat $ATLAS_PROD/sw/atlasinstall_${atlasEnv}/atlasprod/experiment_metadata/$fixesFile | sed 's|[[:space:]]*$||g') ; do
+    for l in $(cat $fixesFilePath/$fixesFile | sed 's|[[:space:]]*$||g') ; do
 	    if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then
 	        warn "ERROR: $exp/$exp.${fileTypeToBeFixed} not found or is empty"
 	        return 1
@@ -219,22 +219,23 @@ applyFixes() {
 
 applyAllFixesForExperiment() {
     exp=$1
+    fixesfilepath=$2
     echo "Applying fixes for $exp ..."
     # Apply factor type fixes in idf file
-    applyFixes $exp automatic_fixes_properties.txt idf.txt
+    applyFixes $exp automatic_fixes_properties.txt idf.txt $fixesfilepath
     if [ $? -ne 0 ]; then
 	    warn "ERROR: Applying factor type fixes in idf file for $exp failed"
 	    return 1
     fi
 
     # Apply factor/sample characteristic type fixes to the condensed-sdrf file
-    applyFixes $exp automatic_fixes_properties.txt condensed-sdrf.tsv
+    applyFixes $exp automatic_fixes_properties.txt condensed-sdrf.tsv $fixesfilepath
     if [ $? -ne 0 ]; then
 	    echo "ERROR: Applying sample characteristic/factor types fixes in sdrf file for $exp failed" >&2
 	    return 1
     fi
     # Apply sample characteristic/factor value fixes to the condensed-sdrf file
-    applyFixes $exp automatic_fixes_values.txt condensed-sdrf.tsv
+    applyFixes $exp automatic_fixes_values.txt condensed-sdrf.tsv $fixesfilepath
     if [ $? -ne 0 ]; then
 	    echo "ERROR: Applying sample characteristic/factor value fixes in sdrf file for $exp failed" >&2
 	    return 1


### PR DESCRIPTION
Summary of the changes:
- delete `atlas_env()`: We don't need this old routine anymore, we can git checkout branches of atlas_prod.
- edit `applyAllFixesForExperiment()`: updates to the working code [here](https://github.com/ebi-gene-expression-group/bulk-recalculations/blob/develop/bin/reprocessing_routines.sh)
- edit `applyAllFixes()`: updates to the working code [here](https://github.com/ebi-gene-expression-group/bulk-recalculations/blob/develop/bin/reprocessing_routines.sh)