### PR TITLE
Allow other conda env paths to be activated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bash utilities used by Expression Atlas [![Anaconda-Server Badge](https://anaconda.org/ebi-gene-expression-group/atlas-bash-util/badges/installer/conda.svg)](https://anaconda.org/ebi-gene-expression-group/atlas-bash-util)
+# Bash utilities used by Expression Atlas [![Anaconda-Server Badge](https://anaconda.org/ebi-gene-expression-group/atlas-bash-util/badges/version.svg)](https://anaconda.org/ebi-gene-expression-group/atlas-bash-util)
 
 This is a module factored out of legacy code to provide common bash utilities to Atlas scripts. 
 

--- a/lsf.sh
+++ b/lsf.sh
@@ -29,7 +29,9 @@ lsf_submit(){
     if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
     if [ -n "$condaEnv" ]; then
         condaBase=$(conda info --json | awk '/conda_prefix/ { gsub(/"|,/, "", $2); print $2 }')
-        condaCmd=". ${condaBase}/bin/activate ${condaBase}/envs/${condaEnv}"
+        condaEnvPath="${condaBase}/envs/${condaEnv}"
+        if [ -d "$condaEnv" ]; then condaEnvPath="$condaEnv"; fi
+        condaCmd=". ${condaBase}/bin/activate ${condaEnvPath}"
         commandString="${condaCmd} && ${commandString}"
     fi
     if [ -n "$logPrefix" ]; then 


### PR DESCRIPTION
This fix allows conda env paths other than those insde the conda base path to be activated using an LSF job submission.