### PR TITLE
peach API fixes 

### DIFF
--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -3,7 +3,7 @@
 IFS="
 "
 
-PEACH_API_URI=${PEACH_API_URI:'http://peach.ebi.ac.uk:8480/api'}
+PEACH_API_URI=${PEACH_API_URI:-'http://peach.ebi.ac.uk:8480/api'}
 
 # Check that a given variable is defined
 

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -104,7 +104,7 @@ peach_api_privacy_status() {
     #fi
     #
     #echo $privacyStatus
-    echo " peach_api_privacy_status function is deprecated "
+    echo "Privacy status can no longer be obtained via the Peach API"
 }
 
 peach_api_release_date() {
@@ -125,7 +125,7 @@ peach_api_release_date() {
     #fi
     #
     #echo $releaseDate
-    echo " peach_api_release_date function is deprecated "
+    echo "Release date information can no longer be obtained from the Peach API."
 }
 
 enad_experiment() {

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -3,7 +3,8 @@
 IFS="
 "
 
-PEACH_API_URI=${PEACH_API_URI:-'http://peach.ebi.ac.uk:8480/api'}
+# deprecated by biostudies
+#PEACH_API_URI=${PEACH_API_URI:-'http://peach.ebi.ac.uk:8480/api'}
 
 # Check that a given variable is defined
 
@@ -89,40 +90,42 @@ function capitalize_first_letter {
 ## -GEOD-/-ERAD-/-ENAD- are loaded as public from now on
 peach_api_privacy_status() {
     expAcc=$1
-    exp_import=$(echo $expAcc | awk -F"-" '{print $2}')
-
-    if [ $exp_import == "MTAB" ]; then
-        response=$(curl -s "${PEACH_API_URI}/privacy.txt?acc=$expAcc")
-        if [ -z "$response" ]; then
-            die "WARNING: Got empty response from ${PEACH_API_URI}/privacy.txt?acc=$expAcc" 0
-        fi
-        privacyStatus=$(echo $response | awk '{print $2}' | awk -F":" '{print $2}')
-        ## if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as public
-    else
-        privacyStatus=$(echo "public")
-    fi
-
-    echo $privacyStatus
+    #exp_import=$(echo $expAcc | awk -F"-" '{print $2}')
+    #
+    #if [ $exp_import == "MTAB" ]; then
+    #    response=$(curl -s "${PEACH_API_URI}/privacy.txt?acc=$expAcc")
+    #    if [ -z "$response" ]; then
+    #        die "WARNING: Got empty response from ${PEACH_API_URI}/privacy.txt?acc=$expAcc" 0
+    #    fi
+    #    privacyStatus=$(echo $response | awk '{print $2}' | awk -F":" '{print $2}')
+    #    ## if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as public
+    #else
+    #    privacyStatus=$(echo "public")
+    #fi
+    #
+    #echo $privacyStatus
+    echo " peach_api_privacy_status function is deprecated "
 }
 
 peach_api_release_date() {
     expAcc=$1
-    exp_import=$(echo $expAcc | awk -F"-" '{print $2}')
-
-    if [ $exp_import == "MTAB" ]; then
-        response=$(curl -s "$PEACH_API_URI/privacy.txt?acc=$expAcc")
-        if [ -z "$response" ]; then
-            die "WARNING: Got empty response from ${PEACH_API_URI}/privacy.txt?acc=$expAcc" 0
-        fi
-        releaseDate=$(echo $response | awk '{print $3}' | awk -F":" '{print $2}')
-
-    ## if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as of today, considering its public and have release date
-    ## not less than 2 days
-    else
-        releaseDate="$(date --date="2 days ago" +%Y-%m-%d)"
-    fi
-
-    echo $releaseDate
+    #exp_import=$(echo $expAcc | awk -F"-" '{print $2}')
+    #
+    #if [ $exp_import == "MTAB" ]; then
+    #    response=$(curl -s "$PEACH_API_URI/privacy.txt?acc=$expAcc")
+    #    if [ -z "$response" ]; then
+    #        die "WARNING: Got empty response from ${PEACH_API_URI}/privacy.txt?acc=$expAcc" 0
+    #    fi
+    #    releaseDate=$(echo $response | awk '{print $3}' | awk -F":" '{print $2}')
+    #
+    ### if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as of today, considering its public and have release date
+    ### not less than 2 days
+    #else
+    #    releaseDate="$(date --date="2 days ago" +%Y-%m-%d)"
+    #fi
+    #
+    #echo $releaseDate
+    echo " peach_api_release_date function is deprecated "
 }
 
 enad_experiment() {

--- a/lsf.sh
+++ b/lsf.sh
@@ -30,7 +30,7 @@ lsf_submit(){
     if [ -n "$condaEnv" ]; then
         condaBase=$(conda info --json | awk '/conda_prefix/ { gsub(/"|,/, "", $2); print $2 }')
         #condaCmd=". ${condaBase}/bin/activate ${condaBase}/envs/${condaEnv}"
-        ###### the lines below were added to enable conda env loading in running node
+        ###### the lines below were added to enable the activation of a conda env that is not inside the base conda env directory
         condaEnvPath="${condaBase}/envs/${condaEnv}"
         if [ -d "$condaEnv" ]; then condaEnvPath="$condaEnv"; fi
         condaCmd=". ${condaBase}/bin/activate ${condaEnvPath}"

--- a/lsf.sh
+++ b/lsf.sh
@@ -29,9 +29,12 @@ lsf_submit(){
     if [ -n "$workingDir" ]; then workingDir=" -cwd \"$workingDir\""; fi
     if [ -n "$condaEnv" ]; then
         condaBase=$(conda info --json | awk '/conda_prefix/ { gsub(/"|,/, "", $2); print $2 }')
+        #condaCmd=". ${condaBase}/bin/activate ${condaBase}/envs/${condaEnv}"
+        ###### the lines below were added to enable conda env loading in running node
         condaEnvPath="${condaBase}/envs/${condaEnv}"
         if [ -d "$condaEnv" ]; then condaEnvPath="$condaEnv"; fi
         condaCmd=". ${condaBase}/bin/activate ${condaEnvPath}"
+        ######
         commandString="${condaCmd} && ${commandString}"
     fi
     if [ -n "$logPrefix" ]; then 


### PR DESCRIPTION
The Peach API (http://peach.ebi.ac.uk:8480/api) has been deprecated by BioStudies  so the functions that rely on it won't work anymore
- peach_api_privacy_status() 
- peach_api_release_date()

This information is now available to the Atlas team by an internal file.

Further work might be necessary to enable external access.