### PR TITLE
Fir error - unbound variable

### DIFF
--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -186,7 +186,7 @@ applyFixes() {
     fixesFilePath=$2
     fileTypeToBeFixed=$3
 
-    echo "NOTE: Fix will not be applied in lines of fixesFile that miss a tab character"
+    echo "NOTE: Fix will not be applied in lines of fixes File that miss a tab character"
     # Apply factor type fixes in ${fileTypeToBeFixed} file
     for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g'); do
         if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then

--- a/generic_routines.sh
+++ b/generic_routines.sh
@@ -186,7 +186,7 @@ applyFixes() {
     fixesFilePath=$2
     fileTypeToBeFixed=$3
 
-    echo "NOTE: Fix will not be applied in lines of $fixesFile that miss a tab character"
+    echo "NOTE: Fix will not be applied in lines of fixesFile that miss a tab character"
     # Apply factor type fixes in ${fileTypeToBeFixed} file
     for l in $(cat $fixesFilePath | sed 's|[[:space:]]*$||g'); do
         if [ ! -s "$exp/$exp.${fileTypeToBeFixed}" ]; then


### PR DESCRIPTION
The new version of Snakemake running in SLURM complains about

`generic_routines.sh: line 189: fixesFile: unbound variable`

this PR should solve it.