### PR TITLE
Add summary statistics to slurm monitoring logs

### DIFF
--- a/atlas-slurm
+++ b/atlas-slurm
@@ -134,9 +134,9 @@ else
         logFile=
         if [ -n "$logPrefix" ]; then
             logFile=${logPrefix}.out
-        fi 
-	sleep 10
-	slurm_monitor_job "$slurmJobId" "$pollFreqSecs" "$logFile" "$monitorStyle" "$logCleanup" "$returnStdout" "$quiet"
+        fi
+        sleep 10
+        slurm_monitor_job "$slurmJobId" "$pollFreqSecs" "$logFile" "$monitorStyle" "$logCleanup" "$returnStdout" "$quiet"
         slurmExitCode=$?
 
         if [ $slurmExitCode -ne 0 ]; then

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -141,10 +141,11 @@ else
 
         if [ $slurmExitCode -ne 0 ]; then
             die "Command \"$commandString\" failed" "$slurmExitCode" "$quiet"
-        else
-            # Generate summary statistics
-            summaryStats=$( seff $slurmJobId )
-            warn "\n\n${summaryStats}" "$quiet"
         fi
     fi
+
+    # Generate summary statistics
+    summaryStats=$( seff $slurmJobId )
+    warn "\n\n${summaryStats}" "$quiet"
+
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -143,7 +143,7 @@ else
             die "Command \"$commandString\" failed" "$slurmExitCode" "$quiet"
         else
             # Generate summary statistics
-            summaryStats=$( seff $jobId )
+            summaryStats=$( seff $slurmJobId )
             warn "\n\n${summaryStats}" "$quiet"
         fi
     fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -145,7 +145,7 @@ else
     fi
 
     # Generate summary statistics
-    summaryStats=$( seff $slurmJobId 2> /dev/null )
+    summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
     warn "\n\n${summaryStats}" "$quiet"
 
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -145,7 +145,7 @@ else
     fi
 
     # Generate summary statistics
-    summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
+    summaryStats=$( slurm_resource_usage_summary $slurmJobId )
     warn "\n\n==SLURM job efficiency report==\n${summaryStats}" "$quiet"
 
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -145,7 +145,7 @@ else
     fi
 
     # Generate summary statistics
-    summaryStats=$( seff $slurmJobId )
+    summaryStats=$( seff $slurmJobId 2> /dev/null )
     warn "\n\n${summaryStats}" "$quiet"
 
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -144,8 +144,8 @@ else
         fi
     fi
 
-    # # Generate summary statistics
-    # summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
-    # warn "\n\n${summaryStats}" "$quiet"
+    # Generate summary statistics
+    summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
+    warn "\n\n==SLURM job efficiency report==\n${summaryStats}" "$quiet"
 
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -144,12 +144,4 @@ else
         fi
     fi
 
-    # Generate summary statistics
-    summaryStats=$( slurm_resource_usage_summary $slurmJobId )
-    if [[ -z "$summaryStats" ]]; then
-        warn "Warning: No SLURM job efficiency report generated." "$quiet"
-    else
-        warn "\n\n==SLURM job efficiency report==\n${summaryStats}" "$quiet"
-    fi
-
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -146,6 +146,10 @@ else
 
     # Generate summary statistics
     summaryStats=$( slurm_resource_usage_summary $slurmJobId )
-    warn "\n\n==SLURM job efficiency report==\n${summaryStats}" "$quiet"
+    if [[ -z "$summaryStats" ]]; then
+        warn "Warning: No SLURM job efficiency report generated." "$quiet"
+    else
+        warn "\n\n==SLURM job efficiency report==\n${summaryStats}" "$quiet"
+    fi
 
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -144,8 +144,8 @@ else
         fi
     fi
 
-    # Generate summary statistics
-    summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
-    warn "\n\n${summaryStats}" "$quiet"
+    # # Generate summary statistics
+    # summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
+    # warn "\n\n${summaryStats}" "$quiet"
 
 fi

--- a/atlas-slurm
+++ b/atlas-slurm
@@ -141,6 +141,10 @@ else
 
         if [ $slurmExitCode -ne 0 ]; then
             die "Command \"$commandString\" failed" "$slurmExitCode" "$quiet"
+        else
+            # Generate summary statistics
+            summaryStats=$( seff $jobId )
+            warn "\n\n${summaryStats}" "$quiet"
         fi
     fi
 fi

--- a/slurm.sh
+++ b/slurm.sh
@@ -145,7 +145,7 @@ slurm_resource_usage_summary(){
 
     check_variables 'jobId'
 
-    local jobInfo="$(seff $jobId 2> /dev/null )"
+    local jobInfo="$(seff $jobId )"
 
     echo "${jobInfo}"
 }

--- a/slurm.sh
+++ b/slurm.sh
@@ -287,8 +287,8 @@ slurm_monitor_job() {
         # complete, which we want before we kill the tail
         slurmLogStatus=$(slurm_completed_job_status_from_sacct "$jobStdout" "$jobId" "yes")
         
-        # Add summary statistics
-        summaryStats="$(slurm_resource_usage_summary $jobId)"
+        # Generate summary statistics
+        summaryStats=$( seff $jobId )
         warn "\n\n${summaryStats}" "$quiet"
 
         # If we're tracking the logs, kill the tail processes

--- a/slurm.sh
+++ b/slurm.sh
@@ -135,6 +135,18 @@ slurm_job_status_from_sacct() {
     return $jobExitCode
 }
 
+# Get slurm job accounting info
+
+slurm_resource_usage_summary(){
+    local jobId=$1
+
+    check_variables 'jobId'
+
+    local jobInfo="$(seff $jobId)"
+
+    return $jobInfo
+}
+
 # Check slurm status for a job
 
 slurm_completed_job_status_from_sacct() {
@@ -164,7 +176,7 @@ slurm_completed_job_status_from_sacct() {
         die "$jobStdout still absent, something strange with job $jobId"
     fi
     
-    # Wait for log file to be complete
+    # Wait for log file to be complete (change this into lsof or fuserf, but currently being tested #########)
 
     local logComplete=1
     checkCount=0
@@ -204,6 +216,10 @@ slurm_completed_job_status_from_sacct() {
         jobReason=${jobStatus}
         warn "Job $jobId had exit status ${jobStatus}, error code $jobExitCode and reason $jobReason" "$quiet"
     fi
+
+    # Add summary statistics
+    summaryStats="$(slurm_resource_usage_summary $jobId)"
+    warn "\n\n${summaryStats}" "$quiet"
 
     echo -n "$jobStatus"
     return $jobExitCode

--- a/slurm.sh
+++ b/slurm.sh
@@ -179,7 +179,7 @@ slurm_completed_job_status_from_sacct() {
         die "$jobStdout still absent, something strange with job $jobId"
     fi
     
-    # Wait for log file to be complete (change this into lsof or fuserf, but currently being tested #########)
+    # Wait for log file to be complete
 
     local logComplete=1
     checkCount=0
@@ -276,6 +276,11 @@ slurm_monitor_job() {
             lastStatus=$slurmJobStatus
         fi
     done
+
+    # Generate summary statistics
+    summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
+    # warn "\n\n${summaryStats}" "$quiet"
+    echo -e "\n\n${summaryStats}"
 
     if [ "$monitorStyle" = 'status' ]; then warn "\n" "$quiet"; fi
 

--- a/slurm.sh
+++ b/slurm.sh
@@ -286,10 +286,6 @@ slurm_monitor_job() {
         # Checking the status from log has the effect of waiting for it to be
         # complete, which we want before we kill the tail
         slurmLogStatus=$(slurm_completed_job_status_from_sacct "$jobStdout" "$jobId" "yes")
-        
-        # Generate summary statistics
-        summaryStats=$( seff $jobId )
-        warn "\n\n${summaryStats}" "$quiet"
 
         # If we're tracking the logs, kill the tail processes
 
@@ -312,6 +308,11 @@ slurm_monitor_job() {
             rm -rf $jobStdout $jobStderr
         fi
     fi
+    
+    # Generate summary statistics
+    summaryStats=$( seff $jobId )
+    warn "\n\n${summaryStats}" "$quiet"
+
     return $slurmExitCode
 }
 

--- a/slurm.sh
+++ b/slurm.sh
@@ -220,10 +220,6 @@ slurm_completed_job_status_from_sacct() {
         warn "Job $jobId had exit status ${jobStatus}, error code $jobExitCode and reason $jobReason" "$quiet"
     fi
 
-    # Add summary statistics
-    summaryStats="$(slurm_resource_usage_summary $jobId)"
-    warn "\n\n${summaryStats}" "$quiet"
-
     echo -n "$jobStatus"
     return $jobExitCode
 }
@@ -290,6 +286,10 @@ slurm_monitor_job() {
         # Checking the status from log has the effect of waiting for it to be
         # complete, which we want before we kill the tail
         slurmLogStatus=$(slurm_completed_job_status_from_sacct "$jobStdout" "$jobId" "yes")
+        
+        # Add summary statistics
+        summaryStats="$(slurm_resource_usage_summary $jobId)"
+        warn "\n\n${summaryStats}" "$quiet"
 
         # If we're tracking the logs, kill the tail processes
 

--- a/slurm.sh
+++ b/slurm.sh
@@ -308,10 +308,6 @@ slurm_monitor_job() {
             rm -rf $jobStdout $jobStderr
         fi
     fi
-    
-    # Generate summary statistics
-    summaryStats=$( seff $jobId )
-    warn "\n\n${summaryStats}" "$quiet"
 
     return $slurmExitCode
 }

--- a/slurm.sh
+++ b/slurm.sh
@@ -285,6 +285,14 @@ slurm_monitor_job() {
         # complete, which we want before we kill the tail
         slurmLogStatus=$(slurm_completed_job_status_from_sacct "$jobStdout" "$jobId" "yes")
 
+        # Generate summary statistics
+        summaryStats=$( slurm_resource_usage_summary $slurmJobId )
+        if [[ -z "$summaryStats" ]]; then
+            warn "Warning: No SLURM job efficiency report generated." "$quiet"
+        else
+            warn "\n\n==SLURM job efficiency report==\n${summaryStats}" "$quiet"
+        fi
+
         # If we're tracking the logs, kill the tail processes
 
         if [ "$monitorStyle" = 'std_out_err' ]; then

--- a/slurm.sh
+++ b/slurm.sh
@@ -32,6 +32,13 @@ slurm_submit(){
         mkdir -p $(dirname $logPrefix)
         logPrefix=" -o \"${logPrefix}.out\" -e \"${logPrefix}.err\""
     fi
+
+    # This is to prioritise a job; test first, then add $priority to the sbatch command
+    # priority=""
+    # if [ "$prioritise" = 'yes' ]; then
+    #     warn "Prioritising $jobId" "$quiet"
+    #     priority=1000000
+    # fi
     
     local sbatch_cmd=$(echo -e "sbatch -t $maxTime $jobQueue $jobName $slurmMem $nThreads $workingDir $logPrefix --wrap \"$commandString\"" | tr -s " ")
     warn "$sbatch_cmd"
@@ -45,10 +52,6 @@ slurm_submit(){
     else
         local jobId=$(echo $sbatchOutput | grep -oE 'Submitted batch job [0-9]+')
         job_id=${jobId##* }
-        # if [ "$prioritise" = 'yes' ]; then
-        #     warn "Prioritising $jobId" "$quiet"
-        #     btop $jobId
-        # fi
         echo $job_id
     fi
 }

--- a/slurm.sh
+++ b/slurm.sh
@@ -138,16 +138,16 @@ slurm_job_status_from_sacct() {
     return $jobExitCode
 }
 
-# Get slurm job accounting info
+# Get slurm job resource usage and efficiency statistics
 
 slurm_resource_usage_summary(){
     local jobId=$1
 
     check_variables 'jobId'
 
-    local jobInfo="$(seff $jobId)"
+    local jobInfo="$(seff $jobId 2> /dev/null )"
 
-    return $jobInfo
+    echo "${jobInfo}"
 }
 
 # Check slurm status for a job

--- a/slurm.sh
+++ b/slurm.sh
@@ -181,8 +181,8 @@ slurm_completed_job_status_from_sacct() {
     
     # Wait for log file to be complete
 
-    local logComplete=1
-    checkCount=0
+    # local logComplete=1
+    # checkCount=0
 
     # while [ "$logComplete" -eq "1" ]; do
     #     grep -q "for stderr output of this job." $jobStdout
@@ -196,7 +196,6 @@ slurm_completed_job_status_from_sacct() {
     # fi
 
     # Now get the info part of the log
-
 
     local jobInfo="$(sacct -j $jobId --format=jobid,state,exitCode,reason --noheader | grep -vE '\.ba\+|\.ex\+' -m 1)" #ignores .ba and .ex entries
     local jobStatus=$(echo -e "$jobInfo" | awk '{print $2}')
@@ -212,7 +211,6 @@ slurm_completed_job_status_from_sacct() {
         if [ -z "$jobExitCode" ]; then
             jobExitCode=1
         fi
-
         warn "Job $jobId had exit status ${jobStatus}, error code $jobExitCode, check standard out $jobStdout and for error message check $jobStderr" "$quiet"
     else
         jobExitCode=$(echo -e "$jobInfo" | awk '{print $3}' | cut -d':' -f1)
@@ -276,11 +274,6 @@ slurm_monitor_job() {
             lastStatus=$slurmJobStatus
         fi
     done
-
-    # Generate summary statistics
-    summaryStats=$( slurm_resource_usage_summary $slurmJobId 2> /dev/null )
-    # warn "\n\n${summaryStats}" "$quiet"
-    echo -e "\n\n${summaryStats}"
 
     if [ "$monitorStyle" = 'status' ]; then warn "\n" "$quiet"; fi
 


### PR DESCRIPTION
These changes add SLURM job usage and efficiency summary statistics when a job exits.  This attempts to mimic the LSF usage summary statistics that is printed to stdout by default at the end of an LSF run.  Some processes, e.g., ISL, use these statistics to improve resource allocation requests in job resubmissions.